### PR TITLE
Resolve issues #19-#22: image spec, presets, QA, and docs policy

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -73,6 +73,12 @@ import {
 - `qaResult?: { hasIssues: boolean; issues: QAIssue[] }`
 - `metadata: { slideCount: number; generatedAt: Date }`
 
+`QAIssue.code` 例:
+- `OUTPUT_NOT_FOUND`
+- `EMPTY_OUTPUT`
+- `OUT_OF_BOUNDS`
+- `EXCESSIVE_OVERLAP`
+
 ## Core DSL Types
 - `PresentationDSL`
   - `metadata`: `title/author/company/date` に加え `copyright`, `footerText` を指定可能
@@ -80,6 +86,10 @@ import {
     - `header.divider`: ヘッダー領域と本文を分離する区切り線
     - `footer`: 左テキスト + ページ番号 + 任意の区切り線
 - `Slide` (`title` / `content` / `section` / `blank`)
+- `content` slide
+  - `layout?`: `auto|single-column|two-column|three-column`
+  - `preset?`: `overview-2x2|compare-3col|kpi-with-callout`
+  - `preset` 指定時は `layout` より優先
 - `ContentElement`
   - `text`
   - `bullet-list`
@@ -92,6 +102,23 @@ import {
   - `flowchart`
   - `icon-grid`
   - `two-column`
+  - 共通で `slot?`（preset 使用時の配置先）と `qa.exclude?`（QA 判定除外）を指定可能
+
+`image` の描画仕様:
+- `sizing`
+  - `contain`: アスペクト比を維持して全体表示（余白あり）
+  - `cover`: 指定領域を埋めるようにトリミング
+  - `crop`: 明示トリミング（現行は `cover` と同じく領域埋め + トリミング）
+- `position` (`left` / `center` / `right`)
+  - `contain` 時の水平配置に使用
+  - `cover` / `crop` 時の水平トリミングアンカーに使用
+- `bounds`
+  - `blank` slide: そのまま配置座標として使用
+  - `content` slide: レイアウト計算結果より優先して上書き可能
+
+`preset` の検証仕様:
+- 未定義 preset ID は `ValidationError`
+- 未定義 slot / 重複 slot / slot と要素 type の不一致は `ValidationError`
 
 詳細型定義:
 - `src/types/dsl.ts`

--- a/docs/template-design-spec.md
+++ b/docs/template-design-spec.md
@@ -1,64 +1,69 @@
-# Template Design Spec (Venture Teal)
+# Template Design Spec
 
 ## Objective
 
-Define a reusable slide template that keeps visual quality stable without requiring complex YAML.
+再利用可能なスライド設計ルールを明確化し、利用者が「推奨運用」と「例外運用」を判断できる状態を作る。
 
-## Scope
+## Rule Levels
 
-- Use template-driven common decorations instead of absolute positioning in deck YAML.
-- Keep content YAML shallow and predictable.
-- Ensure margin, readability, and visual consistency in generated PPTX.
+### Must (壊れる/バリデーション必須)
 
-## YAML Rules
+- DSL はスキーマ検証に合格すること。
+- `content.preset` を使う場合は定義済み preset ID を使うこと。
+- `content.preset` を使う場合、`slot` は preset で定義された名前のみ使うこと。
+- `slot` の要素タイプ制約（許容 type）を満たすこと。
+- 画像パスは安全なローカルパスまたは data URL を使うこと（既定では remote URL 不可）。
 
-- Prefer `content` slides with `layout: auto` or `layout: two-column`.
-- Avoid `blank` slides except for special cases.
-- Do not nest `two-column` inside `two-column`.
-- Keep 3-5 primary content elements per slide.
-- Use theme tokens for colors and fonts whenever possible.
+### Should (壊れないが推奨)
+
+- 定型業務スライドは `content + preset` を優先し、`blank` を常用しない。
+- `preset` を使わない場合は `layout: auto/two-column` を優先する。
+- 1スライドの主要要素は 3-5 個に収める。
+- 色・フォントはテーマトークンを優先し、ハードコードを減らす。
+- `blank` 利用時は decorative 要素（背景 shape）と情報要素を分離する。
+
+### May (例外許容)
+
+- `blank` を使った絶対座標レイアウト（アートボード/特殊図版）。
+- `content` で `bounds` を使った要素単位の微調整。
+- preset の `default` slot に複数要素を積む運用（縦スタック）。
+
+## Layout/Preset Selection
+
+| ユースケース | 推奨 |
+| --- | --- |
+| 定型の KPI/比較/サマリ | `content.preset` |
+| 混在要素の一般スライド | `content.layout: auto` |
+| テキスト左・図右が明確 | `content.layout: two-column` |
+| 例外的な自由配置・ポスター型 | `blank`（制約付き） |
+
+## Preset Catalog (MVP)
+
+- `overview-2x2`: 4カード構成の概観スライド。
+- `compare-3col`: 3カラム比較 + 下段サマリ。
+- `kpi-with-callout`: KPI領域 + 右側コールアウト。
+
+`preset` 指定時は `layout` より `preset` を優先する。
+
+## Blank Slide Constraints
+
+- `custom-shape` は既定で decorative 扱い（QA overlap 判定から除外）。
+- 情報要素同士の過度な重なりは QA 警告対象。
+- 要素はスライド境界内に収める。
 
 ## Template Responsibilities
 
-The template package defines:
+テンプレートパッケージは以下を提供する:
 
-- header divider line (header と本文の分離)
-- soft corner circles as background motifs
-- title placeholder bounds
-- body placeholder bounds
-- footer chrome (`leftText` + slide number)
-- adaptive footer placement (top on light slides, bottom on dark slides)
+- `title/body` placeholder
+- background color/image/objects
+- optional footer chrome
 
-These are applied uniformly through `templatePackagePath`, so each slide inherits the same frame.
+`preset/layout` で解決した要素 bounds は、template の body placeholder に再マップされる。
 
-## DSL Chrome (Templateなしの場合)
+## PR Review Checklist
 
-`templatePackagePath` を使わない場合でも、DSLの `chrome` で以下を指定可能:
-
-- `chrome.header.divider`: header と main content を分ける線
-- `chrome.footer`: ページ番号と左側テキスト
-- `metadata.company` / `metadata.copyright` / `metadata.footerText`
-  をフッター文言に差し替え可能
-
-## Recommended Layout: 4-Point Spotlight
-
-4つの重要観点を短く強調する用途では、以下の構成を推奨:
-
-- 上段: section label + main title
-- 中央: 2x2カード（各カードは `label + icon + value`）
-- 下段: 1行の強調メッセージバー
-
-実装例:
-- `example/template-gallery/presentation.yaml` の最終スライド
-
-## Placeholder Contract
-
-- `title` placeholder: one-line slide heading area
-- `body` placeholder: primary content canvas
-
-All slide content must fit inside these placeholders via auto layout. No per-slide coordinate tuning is expected.
-
-## Tradeoffs
-
-- Exact original PPT decoration parity is not required.
-- Deterministic, low-maintenance generation is prioritized over pixel-perfect replication.
+- Must/Should/May のいずれに該当する変更かを説明したか。
+- 新規 preset/slot 追加時に validator と docs を同時更新したか。
+- `blank` 運用の例外理由（なぜ preset/layout で足りないか）を明記したか。
+- `npm run quality:check` を通過したか。

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -78,6 +78,71 @@ const dsl: PresentationDSL = {
 };
 ```
 
+## 3.2 画像要素の `sizing` / `position` / `bounds`
+
+```yaml
+slides:
+  - type: content
+    title: "Image sample"
+    content:
+      - type: image
+        source: "example/assets/hero.png"
+        sizing: "cover"   # contain | cover | crop
+        position: "right" # left | center | right
+        bounds:           # 任意: layout 計算結果を上書き
+          x: 1.0
+          y: 1.4
+          w: 8.0
+          h: 3.6
+```
+
+- `contain`: アスペクト比を維持して全体表示（余白あり）
+- `cover`: 指定領域を埋めるようにトリミング
+- `crop`: 明示トリミング（現行は `cover` と同等の挙動）
+- `position`: `contain` では配置、`cover/crop` では水平トリミングのアンカーとして機能
+- `bounds`: `blank` では絶対配置、`content` ではレイアウト結果の上書きに使用可能
+
+## 3.3 推奨フロー（Must / Should / May）
+
+- Must: スキーマ検証と preset/slot 制約を満たす
+- Should: 定型スライドは `content + preset` を優先
+- May: 例外的に `blank` で自由配置
+
+### レイアウト選定の目安
+
+| 状況 | 推奨 |
+| --- | --- |
+| KPI/比較など定型スライド | `preset` |
+| 一般的な本文スライド | `layout: auto` |
+| 左右分割が明確 | `layout: two-column` |
+| 特殊な自由配置 | `blank` |
+
+### preset 利用例
+
+```yaml
+slides:
+  - type: content
+    title: "Business Overview"
+    preset: "overview-2x2"
+    content:
+      - type: stat-callout
+        slot: card1
+        value: "98%"
+        label: "NPS"
+      - type: stat-callout
+        slot: card2
+        value: "2.3x"
+        label: "YoY"
+      - type: stat-callout
+        slot: card3
+        value: "12"
+        label: "Markets"
+      - type: stat-callout
+        slot: card4
+        value: "7 days"
+        label: "Lead Time"
+```
+
 ## 4. オプション
 
 ```ts
@@ -97,6 +162,11 @@ const renderer = new PPTXRenderer({
 - `qaConfig.maxIterations`: 自動修正の最大反復回数
 - `allowRemoteImages`: リモート画像 URL を許可（既定は `false`）
 - `themeDir`: テーマ解決の基準ディレクトリ
+
+QA 検証の主な対象:
+- `content/blank` 要素の `OUT_OF_BOUNDS`
+- `blank` 上の非装飾要素同士の過度な重なり（`EXCESSIVE_OVERLAP`）
+- `custom-shape` は既定で decorative 扱い（overlap 判定除外）
 
 ## 5. 実サンプル実行
 

--- a/example/README.md
+++ b/example/README.md
@@ -12,6 +12,9 @@ This directory provides production-style sample decks and scripts.
 - `template-import`: import a `.pptx/.potx` file as a reusable template package
 - `templates/venture-teal/template.yaml`: shared template for common decorations and placeholder bounds
 
+Preset-aware authoring:
+- `content.preset` (`overview-2x2` / `compare-3col` / `kpi-with-callout`) と `slot` を使うと、`blank` の絶対座標を減らせます。
+
 ## Run all examples
 
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,6 +272,7 @@ export class PPTXRenderer {
 export * from "./errors";
 export * from "./layout";
 export * from "./parser";
+export * from "./presets";
 export * from "./qa";
 export * from "./renderers";
 export * from "./template-importer";

--- a/src/layout/element-bounds.ts
+++ b/src/layout/element-bounds.ts
@@ -1,0 +1,47 @@
+import type { Bounds, ContentElement, CustomShapeElement } from "../types";
+
+export const DEFAULT_BLANK_ELEMENT_BOUNDS: Bounds = {
+  x: 0.8,
+  y: 0.8,
+  w: 8.4,
+  h: 4.0
+};
+
+function cloneBounds(bounds: Bounds): Bounds {
+  return {
+    x: bounds.x,
+    y: bounds.y,
+    w: bounds.w,
+    h: bounds.h
+  };
+}
+
+function isBounds(value: unknown): value is Bounds {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const candidate = value as Partial<Bounds>;
+  return (
+    typeof candidate.x === "number" &&
+    typeof candidate.y === "number" &&
+    typeof candidate.w === "number" &&
+    typeof candidate.h === "number"
+  );
+}
+
+export function resolveElementBounds(element: ContentElement | CustomShapeElement, fallbackBounds: Bounds): Bounds {
+  if (element.type === "custom-shape") {
+    return cloneBounds(element.position);
+  }
+
+  if (isBounds(element.position)) {
+    return cloneBounds(element.position);
+  }
+
+  if (element.type === "image" && isBounds(element.bounds)) {
+    return cloneBounds(element.bounds);
+  }
+
+  return cloneBounds(fallbackBounds);
+}

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -1,4 +1,5 @@
 export * from "./constraints";
 export * from "./engine";
+export * from "./element-bounds";
 export * from "./algorithms/hierarchical";
 export * from "./algorithms/force-directed";

--- a/src/parser/schema.ts
+++ b/src/parser/schema.ts
@@ -5,6 +5,12 @@ import { themeDefinitionSchema } from "../theme/schema";
 
 const boundedString = z.string().min(1).max(MAX_STRING_LENGTH);
 const optionalBoundedString = z.string().min(1).max(MAX_STRING_LENGTH).optional();
+const elementQASchema = z
+  .object({
+    exclude: z.boolean().optional()
+  })
+  .strict();
+const presetIdSchema = z.union([z.literal("overview-2x2"), z.literal("compare-3col"), z.literal("kpi-with-callout")]);
 const elementPositionSchema = z
   .object({
     x: z.number(),
@@ -65,6 +71,7 @@ const textElementSchema = z
   .object({
     type: z.literal("text"),
     content: boundedString,
+    slot: optionalBoundedString,
     style: z.union([z.literal("title"), z.literal("heading"), z.literal("body"), z.literal("caption")]).optional(),
     align: z.union([z.literal("left"), z.literal("center"), z.literal("right")]).optional(),
     position: elementPositionSchema.optional(),
@@ -72,7 +79,8 @@ const textElementSchema = z
     fontFace: optionalBoundedString,
     fontSize: z.number().positive().optional(),
     bold: z.boolean().optional(),
-    valign: z.union([z.literal("top"), z.literal("mid"), z.literal("bottom")]).optional()
+    valign: z.union([z.literal("top"), z.literal("mid"), z.literal("bottom")]).optional(),
+    qa: elementQASchema.optional()
   })
   .strict();
 
@@ -86,45 +94,54 @@ const bulletItemSchema = z
 const bulletListElementSchema = z
   .object({
     type: z.literal("bullet-list"),
+    slot: optionalBoundedString,
     style: z.union([z.literal("default"), z.literal("pros"), z.literal("cons"), z.literal("checkmark")]).optional(),
     items: z.array(z.union([boundedString, bulletItemSchema])).max(MAX_ARRAY_LENGTH),
-    position: elementPositionSchema.optional()
+    position: elementPositionSchema.optional(),
+    qa: elementQASchema.optional()
   })
   .strict();
 
 const numberedListElementSchema = z
   .object({
     type: z.literal("numbered-list"),
+    slot: optionalBoundedString,
     items: z.array(boundedString).max(MAX_ARRAY_LENGTH),
-    position: elementPositionSchema.optional()
+    position: elementPositionSchema.optional(),
+    qa: elementQASchema.optional()
   })
   .strict();
 
 const statCalloutElementSchema = z
   .object({
     type: z.literal("stat-callout"),
+    slot: optionalBoundedString,
     value: boundedString,
     label: boundedString,
     trend: optionalBoundedString,
     color: optionalBoundedString,
-    position: elementPositionSchema.optional()
+    position: elementPositionSchema.optional(),
+    qa: elementQASchema.optional()
   })
   .strict();
 
 const imageElementSchema = z
   .object({
     type: z.literal("image"),
+    slot: optionalBoundedString,
     source: boundedString,
     caption: optionalBoundedString,
     sizing: z.union([z.literal("contain"), z.literal("cover"), z.literal("crop")]).optional(),
     position: z.union([z.literal("center"), z.literal("left"), z.literal("right")]).optional(),
-    bounds: elementPositionSchema.optional()
+    bounds: elementPositionSchema.optional(),
+    qa: elementQASchema.optional()
   })
   .strict();
 
 const tableElementSchema = z
   .object({
     type: z.literal("table"),
+    slot: optionalBoundedString,
     style: z.union([z.literal("default"), z.literal("striped"), z.literal("bordered"), z.literal("minimal")]).optional(),
     headers: z.array(boundedString).min(1).max(MAX_ARRAY_LENGTH),
     rows: z.array(z.array(z.union([boundedString, z.number()])).max(MAX_ARRAY_LENGTH)).max(MAX_ARRAY_LENGTH),
@@ -140,13 +157,15 @@ const tableElementSchema = z
           .strict()
       )
       .max(MAX_ARRAY_LENGTH)
-      .optional()
+      .optional(),
+    qa: elementQASchema.optional()
   })
   .strict();
 
 const chartElementSchema = z
   .object({
     type: z.literal("chart"),
+    slot: optionalBoundedString,
     chartType: z.union([
       z.literal("bar"),
       z.literal("line"),
@@ -181,13 +200,15 @@ const chartElementSchema = z
         valueSuffix: optionalBoundedString
       })
       .strict()
-      .optional()
+      .optional(),
+    qa: elementQASchema.optional()
   })
   .strict();
 
 const networkDiagramElementSchema = z
   .object({
     type: z.literal("network-diagram"),
+    slot: optionalBoundedString,
     layout: z.union([z.literal("hierarchical"), z.literal("force-directed"), z.literal("circular")]),
     position: elementPositionSchema.optional(),
     nodes: z
@@ -214,13 +235,15 @@ const networkDiagramElementSchema = z
           })
           .strict()
       )
-      .max(MAX_ARRAY_LENGTH)
+      .max(MAX_ARRAY_LENGTH),
+    qa: elementQASchema.optional()
   })
   .strict();
 
 const flowchartElementSchema = z
   .object({
     type: z.literal("flowchart"),
+    slot: optionalBoundedString,
     direction: z.union([z.literal("horizontal"), z.literal("vertical")]),
     position: elementPositionSchema.optional(),
     steps: z
@@ -245,13 +268,15 @@ const flowchartElementSchema = z
           })
           .strict()
       )
-      .max(MAX_ARRAY_LENGTH)
+      .max(MAX_ARRAY_LENGTH),
+    qa: elementQASchema.optional()
   })
   .strict();
 
 const iconGridElementSchema = z
   .object({
     type: z.literal("icon-grid"),
+    slot: optionalBoundedString,
     columns: z.number().int().positive().max(12),
     position: elementPositionSchema.optional(),
     items: z
@@ -265,7 +290,8 @@ const iconGridElementSchema = z
           .strict()
       )
       .min(1)
-      .max(MAX_ARRAY_LENGTH)
+      .max(MAX_ARRAY_LENGTH),
+    qa: elementQASchema.optional()
   })
   .strict();
 
@@ -275,10 +301,12 @@ const twoColumnElementSchema: z.ZodTypeAny = z.lazy(() =>
   z
     .object({
       type: z.literal("two-column"),
+      slot: optionalBoundedString,
       left: z.array(contentElementSchema).max(MAX_ARRAY_LENGTH),
       right: z.array(contentElementSchema).max(MAX_ARRAY_LENGTH),
       ratio: z.union([z.literal("1:1"), z.literal("2:1"), z.literal("1:2")]).optional(),
-      position: elementPositionSchema.optional()
+      position: elementPositionSchema.optional(),
+      qa: elementQASchema.optional()
     })
     .strict()
 );
@@ -311,7 +339,8 @@ const customShapeElementSchema = z
         width: z.number().positive()
       })
       .strict()
-      .optional()
+      .optional(),
+    qa: elementQASchema.optional()
   })
   .strict();
 
@@ -345,6 +374,7 @@ const contentSlideSchema = z
   .object({
     type: z.literal("content"),
     layout: z.union([z.literal("auto"), z.literal("single-column"), z.literal("two-column"), z.literal("three-column")]).optional(),
+    preset: presetIdSchema.optional(),
     title: boundedString,
     content: z.array(contentElementSchema).max(MAX_ARRAY_LENGTH)
   })

--- a/src/parser/validator.ts
+++ b/src/parser/validator.ts
@@ -5,6 +5,7 @@ import { ValidationError } from "../errors";
 import { presentationDSLSchema } from "./schema";
 import { enforceStructuralLimits } from "../utils/deep-limit";
 import type { ContentElement, PresentationDSL, Slide } from "../types";
+import { DEFAULT_PRESET_SLOT, getPresetDefinition } from "../presets";
 
 export interface ValidationResult {
   isValid: boolean;
@@ -98,6 +99,47 @@ function validateImage(element: ContentElement, errors: string[], location: stri
   }
 }
 
+function validatePreset(slide: Extract<Slide, { type: "content" }>, errors: string[], slideIndex: number): void {
+  if (slide.preset === undefined) {
+    return;
+  }
+
+  const preset = getPresetDefinition(slide.preset);
+  if (preset === undefined) {
+    errors.push(`slides[${slideIndex}].preset references unknown preset '${slide.preset}'`);
+    return;
+  }
+
+  const slotMap = new Map(preset.slots.map((slot) => [slot.name, slot]));
+  const usedSlots = new Map<string, number>();
+
+  slide.content.forEach((element, elementIndex) => {
+    const resolvedSlot = element.slot ?? DEFAULT_PRESET_SLOT;
+    const slotDefinition = slotMap.get(resolvedSlot);
+    if (slotDefinition === undefined) {
+      errors.push(`slides[${slideIndex}].content[${elementIndex}].slot references undefined slot '${resolvedSlot}'`);
+      return;
+    }
+
+    if (resolvedSlot !== DEFAULT_PRESET_SLOT) {
+      const prior = usedSlots.get(resolvedSlot);
+      if (prior !== undefined) {
+        errors.push(
+          `slides[${slideIndex}].content[${elementIndex}].slot duplicates slot '${resolvedSlot}' already used by content[${prior}]`
+        );
+      } else {
+        usedSlots.set(resolvedSlot, elementIndex);
+      }
+    }
+
+    if (slotDefinition.allowedElementTypes !== undefined && !slotDefinition.allowedElementTypes.includes(element.type)) {
+      errors.push(
+        `slides[${slideIndex}].content[${elementIndex}] type '${element.type}' is not allowed in slot '${resolvedSlot}'`
+      );
+    }
+  });
+}
+
 function traverseElements(
   elements: ContentElement[],
   errors: string[],
@@ -123,6 +165,7 @@ function validateSlides(slides: Slide[], allowRemoteImages: boolean): string[] {
   const errors: string[] = [];
   slides.forEach((slide, slideIndex) => {
     if (slide.type === "content") {
+      validatePreset(slide, errors, slideIndex);
       traverseElements(slide.content, errors, `slides[${slideIndex}].content`, allowRemoteImages);
     }
 

--- a/src/presets/catalog.ts
+++ b/src/presets/catalog.ts
@@ -1,0 +1,199 @@
+import type { Bounds, ContentElement, CustomShapeElement, PresetId } from "../types";
+
+export const DEFAULT_PRESET_SLOT = "default";
+
+export interface PresetSlotDefinition {
+  name: string;
+  bounds: Bounds;
+  allowedElementTypes?: ContentElement["type"][];
+}
+
+export interface PresetDefinition {
+  id: PresetId;
+  slots: PresetSlotDefinition[];
+  decorations?: CustomShapeElement[];
+  defaults?: {
+    gap?: number;
+  };
+}
+
+const overview2x2Slots: PresetSlotDefinition[] = [
+  {
+    name: "card1",
+    bounds: { x: 0.8, y: 1.0, w: 4.08, h: 1.88 },
+    allowedElementTypes: ["stat-callout", "text", "bullet-list", "numbered-list", "icon-grid"]
+  },
+  {
+    name: "card2",
+    bounds: { x: 5.12, y: 1.0, w: 4.08, h: 1.88 },
+    allowedElementTypes: ["stat-callout", "text", "bullet-list", "numbered-list", "icon-grid"]
+  },
+  {
+    name: "card3",
+    bounds: { x: 0.8, y: 3.12, w: 4.08, h: 1.88 },
+    allowedElementTypes: ["stat-callout", "text", "bullet-list", "numbered-list", "icon-grid"]
+  },
+  {
+    name: "card4",
+    bounds: { x: 5.12, y: 3.12, w: 4.08, h: 1.88 },
+    allowedElementTypes: ["stat-callout", "text", "bullet-list", "numbered-list", "icon-grid"]
+  },
+  {
+    name: DEFAULT_PRESET_SLOT,
+    bounds: { x: 0.8, y: 1.0, w: 8.4, h: 4.0 }
+  }
+];
+
+const compare3colSlots: PresetSlotDefinition[] = [
+  {
+    name: "left",
+    bounds: { x: 0.8, y: 1.0, w: 2.67, h: 3.1 },
+    allowedElementTypes: ["text", "bullet-list", "numbered-list", "image", "table", "stat-callout"]
+  },
+  {
+    name: "center",
+    bounds: { x: 3.67, y: 1.0, w: 2.67, h: 3.1 },
+    allowedElementTypes: ["text", "bullet-list", "numbered-list", "image", "table", "stat-callout"]
+  },
+  {
+    name: "right",
+    bounds: { x: 6.53, y: 1.0, w: 2.67, h: 3.1 },
+    allowedElementTypes: ["text", "bullet-list", "numbered-list", "image", "table", "stat-callout"]
+  },
+  {
+    name: DEFAULT_PRESET_SLOT,
+    bounds: { x: 0.8, y: 4.25, w: 8.4, h: 0.75 },
+    allowedElementTypes: ["text", "bullet-list", "numbered-list"]
+  }
+];
+
+const kpiWithCalloutSlots: PresetSlotDefinition[] = [
+  {
+    name: "kpi",
+    bounds: { x: 0.8, y: 1.0, w: 5.2, h: 2.4 },
+    allowedElementTypes: ["chart", "stat-callout", "table", "text"]
+  },
+  {
+    name: "narrative",
+    bounds: { x: 0.8, y: 3.55, w: 5.2, h: 1.45 },
+    allowedElementTypes: ["text", "bullet-list", "numbered-list"]
+  },
+  {
+    name: "callout",
+    bounds: { x: 6.2, y: 1.0, w: 3.0, h: 1.9 },
+    allowedElementTypes: ["stat-callout", "text", "icon-grid"]
+  },
+  {
+    name: "trend",
+    bounds: { x: 6.2, y: 3.05, w: 3.0, h: 1.95 },
+    allowedElementTypes: ["chart", "stat-callout", "text", "image"]
+  },
+  {
+    name: DEFAULT_PRESET_SLOT,
+    bounds: { x: 0.8, y: 1.0, w: 8.4, h: 4.0 }
+  }
+];
+
+const presetDefinitions: Record<PresetId, PresetDefinition> = {
+  "overview-2x2": {
+    id: "overview-2x2",
+    slots: overview2x2Slots,
+    decorations: [
+      {
+        type: "custom-shape",
+        shape: "rounded-rectangle",
+        position: { x: 0.76, y: 0.96, w: 4.16, h: 1.96 },
+        fill: "background-light",
+        border: {
+          color: "DEE2E6",
+          width: 0.8
+        }
+      },
+      {
+        type: "custom-shape",
+        shape: "rounded-rectangle",
+        position: { x: 5.08, y: 0.96, w: 4.16, h: 1.96 },
+        fill: "background-light",
+        border: {
+          color: "DEE2E6",
+          width: 0.8
+        }
+      },
+      {
+        type: "custom-shape",
+        shape: "rounded-rectangle",
+        position: { x: 0.76, y: 3.08, w: 4.16, h: 1.96 },
+        fill: "background-light",
+        border: {
+          color: "DEE2E6",
+          width: 0.8
+        }
+      },
+      {
+        type: "custom-shape",
+        shape: "rounded-rectangle",
+        position: { x: 5.08, y: 3.08, w: 4.16, h: 1.96 },
+        fill: "background-light",
+        border: {
+          color: "DEE2E6",
+          width: 0.8
+        }
+      }
+    ],
+    defaults: {
+      gap: 0.08
+    }
+  },
+  "compare-3col": {
+    id: "compare-3col",
+    slots: compare3colSlots,
+    decorations: [
+      {
+        type: "custom-shape",
+        shape: "rectangle",
+        position: { x: 3.56, y: 1.0, w: 0.03, h: 3.1 },
+        fill: "DEE2E6"
+      },
+      {
+        type: "custom-shape",
+        shape: "rectangle",
+        position: { x: 6.43, y: 1.0, w: 0.03, h: 3.1 },
+        fill: "DEE2E6"
+      }
+    ],
+    defaults: {
+      gap: 0.08
+    }
+  },
+  "kpi-with-callout": {
+    id: "kpi-with-callout",
+    slots: kpiWithCalloutSlots,
+    decorations: [
+      {
+        type: "custom-shape",
+        shape: "rounded-rectangle",
+        position: { x: 6.12, y: 0.92, w: 3.16, h: 4.16 },
+        fill: "F8F9FA",
+        border: {
+          color: "DEE2E6",
+          width: 0.8
+        }
+      }
+    ],
+    defaults: {
+      gap: 0.08
+    }
+  }
+};
+
+export function getPresetDefinition(presetId: PresetId): PresetDefinition | undefined {
+  return presetDefinitions[presetId];
+}
+
+export function isPresetId(value: string): value is PresetId {
+  return value in presetDefinitions;
+}
+
+export function listPresetIds(): PresetId[] {
+  return Object.keys(presetDefinitions) as PresetId[];
+}

--- a/src/presets/engine.ts
+++ b/src/presets/engine.ts
@@ -1,0 +1,121 @@
+import { LayoutError } from "../errors";
+import type { Bounds, ContentElement, CustomShapeElement, ElementArea, PresetId } from "../types";
+import { DEFAULT_PRESET_SLOT, getPresetDefinition, type PresetDefinition, type PresetSlotDefinition } from "./catalog";
+
+export interface PresetLayoutResult {
+  frame: Bounds;
+  areas: ElementArea[];
+  decorations: CustomShapeElement[];
+}
+
+function cloneBounds(bounds: Bounds): Bounds {
+  return {
+    x: bounds.x,
+    y: bounds.y,
+    w: bounds.w,
+    h: bounds.h
+  };
+}
+
+function stackBounds(bounds: Bounds, count: number, gap: number): Bounds[] {
+  if (count <= 1) {
+    return [cloneBounds(bounds)];
+  }
+
+  const totalGap = Math.max(0, count - 1) * gap;
+  const eachHeight = Math.max(0.1, (bounds.h - totalGap) / count);
+  return Array.from({ length: count }, (_item, index) => ({
+    x: bounds.x,
+    y: bounds.y + index * (eachHeight + gap),
+    w: bounds.w,
+    h: eachHeight
+  }));
+}
+
+function ensurePresetDefinition(presetId: PresetId): PresetDefinition {
+  const definition = getPresetDefinition(presetId);
+  if (definition === undefined) {
+    throw new LayoutError(`Unsupported preset: ${presetId}`);
+  }
+
+  return definition;
+}
+
+function slotMapFromDefinition(definition: PresetDefinition): Map<string, PresetSlotDefinition> {
+  return new Map(definition.slots.map((slot) => [slot.name, slot]));
+}
+
+function calculateFrame(definition: PresetDefinition): Bounds {
+  const firstSlot = definition.slots[0];
+  if (firstSlot === undefined) {
+    throw new LayoutError(`Preset '${definition.id}' does not define slots`);
+  }
+
+  let minX = firstSlot.bounds.x;
+  let minY = firstSlot.bounds.y;
+  let maxX = firstSlot.bounds.x + firstSlot.bounds.w;
+  let maxY = firstSlot.bounds.y + firstSlot.bounds.h;
+
+  definition.slots.slice(1).forEach((slot) => {
+    minX = Math.min(minX, slot.bounds.x);
+    minY = Math.min(minY, slot.bounds.y);
+    maxX = Math.max(maxX, slot.bounds.x + slot.bounds.w);
+    maxY = Math.max(maxY, slot.bounds.y + slot.bounds.h);
+  });
+
+  return {
+    x: minX,
+    y: minY,
+    w: maxX - minX,
+    h: maxY - minY
+  };
+}
+
+export class PresetEngine {
+  public calculateLayout(elements: ContentElement[], presetId: PresetId): PresetLayoutResult {
+    const definition = ensurePresetDefinition(presetId);
+    const slots = slotMapFromDefinition(definition);
+    const slotAssignments = new Map<string, number[]>();
+
+    elements.forEach((element, index) => {
+      const resolvedSlot = element.slot ?? DEFAULT_PRESET_SLOT;
+      const assigned = slotAssignments.get(resolvedSlot) ?? [];
+      assigned.push(index);
+      slotAssignments.set(resolvedSlot, assigned);
+    });
+
+    const boundsByIndex = new Map<number, Bounds>();
+    const gap = definition.defaults?.gap ?? 0.08;
+
+    slotAssignments.forEach((indices, slotName) => {
+      const slot = slots.get(slotName);
+      if (slot === undefined) {
+        throw new LayoutError(`Preset '${presetId}' does not define slot '${slotName}'`);
+      }
+
+      const splitBounds = stackBounds(slot.bounds, indices.length, gap);
+      indices.forEach((elementIndex, splitIndex) => {
+        boundsByIndex.set(elementIndex, splitBounds[splitIndex] ?? cloneBounds(slot.bounds));
+      });
+    });
+
+    const defaultSlotBounds = slots.get(DEFAULT_PRESET_SLOT)?.bounds;
+    if (defaultSlotBounds === undefined) {
+      throw new LayoutError(`Preset '${presetId}' must define a '${DEFAULT_PRESET_SLOT}' slot`);
+    }
+
+    const areas: ElementArea[] = elements.map((element, index) => ({
+      element,
+      bounds: boundsByIndex.get(index) ?? cloneBounds(defaultSlotBounds)
+    }));
+
+    return {
+      frame: calculateFrame(definition),
+      areas,
+      decorations: (definition.decorations ?? []).map((shape) => ({
+        ...shape,
+        position: cloneBounds(shape.position)
+      }))
+    };
+  }
+}

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,0 +1,2 @@
+export * from "./catalog";
+export * from "./engine";

--- a/src/qa/validator.ts
+++ b/src/qa/validator.ts
@@ -1,7 +1,131 @@
 import * as fs from "node:fs/promises";
-import type { PresentationDSL, QAResult, ThemeDefinition } from "../types";
-import { LayoutEngine } from "../layout";
+import type { BlankSlide, Bounds, PresentationDSL, QAResult, ThemeDefinition } from "../types";
+import { DEFAULT_BLANK_ELEMENT_BOUNDS, LayoutEngine, resolveElementBounds } from "../layout";
+import { PresetEngine } from "../presets";
 import { isInsideBounds } from "../utils/geometry";
+
+const DEFAULT_OVERLAP_THRESHOLD = 0.35;
+
+interface QAResolvedElement {
+  index: number;
+  element: BlankSlide["elements"][number];
+  bounds: Bounds;
+}
+
+function boundsArea(bounds: Bounds): number {
+  return Math.max(0, bounds.w) * Math.max(0, bounds.h);
+}
+
+function intersectionArea(a: Bounds, b: Bounds): number {
+  const x = Math.max(a.x, b.x);
+  const y = Math.max(a.y, b.y);
+  const right = Math.min(a.x + a.w, b.x + b.w);
+  const bottom = Math.min(a.y + a.h, b.y + b.h);
+
+  return Math.max(0, right - x) * Math.max(0, bottom - y);
+}
+
+function overlapRatio(a: Bounds, b: Bounds): number {
+  const areaA = boundsArea(a);
+  const areaB = boundsArea(b);
+  if (areaA <= 0 || areaB <= 0) {
+    return 0;
+  }
+
+  return intersectionArea(a, b) / Math.min(areaA, areaB);
+}
+
+function isDecorativeElement(element: BlankSlide["elements"][number]): boolean {
+  if (element.qa?.exclude === true) {
+    return true;
+  }
+
+  return element.type === "custom-shape";
+}
+
+function validateOutOfBounds(
+  bounds: Bounds,
+  slideBounds: Bounds,
+  issues: QAResult["issues"],
+  slideIndex: number,
+  elementIndex: number
+): void {
+  if (!isInsideBounds(bounds, slideBounds)) {
+    issues.push({
+      code: "OUT_OF_BOUNDS",
+      message: "Layout area exceeded slide bounds",
+      slideIndex,
+      elementIndex
+    });
+  }
+}
+
+function validateBlankOverlap(
+  resolvedElements: QAResolvedElement[],
+  issues: QAResult["issues"],
+  slideIndex: number,
+  threshold: number
+): void {
+  const candidates = resolvedElements.filter(({ element }) => !isDecorativeElement(element));
+  for (let leftIndex = 0; leftIndex < candidates.length; leftIndex += 1) {
+    const left = candidates[leftIndex];
+    if (left === undefined) {
+      continue;
+    }
+
+    for (let rightIndex = leftIndex + 1; rightIndex < candidates.length; rightIndex += 1) {
+      const right = candidates[rightIndex];
+      if (right === undefined) {
+        continue;
+      }
+
+      const ratio = overlapRatio(left.bounds, right.bounds);
+      if (ratio <= threshold) {
+        continue;
+      }
+
+      issues.push({
+        code: "EXCESSIVE_OVERLAP",
+        message: `Elements ${left.index} and ${right.index} overlap excessively (${(ratio * 100).toFixed(1)}%)`,
+        slideIndex,
+        elementIndex: left.index
+      });
+    }
+  }
+}
+
+function validateBlankSlide(slide: BlankSlide, slideIndex: number, slideBounds: Bounds, issues: QAResult["issues"]): void {
+  const resolved = slide.elements.map((element, elementIndex) => ({
+    index: elementIndex,
+    element,
+    bounds: resolveElementBounds(element, DEFAULT_BLANK_ELEMENT_BOUNDS)
+  }));
+
+  resolved.forEach((item) => {
+    validateOutOfBounds(item.bounds, slideBounds, issues, slideIndex, item.index);
+  });
+
+  validateBlankOverlap(resolved, issues, slideIndex, DEFAULT_OVERLAP_THRESHOLD);
+}
+
+function validateContentSlide(
+  slide: Extract<PresentationDSL["slides"][number], { type: "content" }>,
+  slideIndex: number,
+  layoutEngine: LayoutEngine,
+  presetEngine: PresetEngine,
+  slideBounds: Bounds,
+  issues: QAResult["issues"]
+): void {
+  const areas =
+    slide.preset !== undefined
+      ? presetEngine.calculateLayout(slide.content, slide.preset).areas
+      : layoutEngine.calculateLayout(slide.content, slide.layout ?? "auto").areas;
+
+  areas.forEach((area, elementIndex) => {
+    const effectiveBounds = resolveElementBounds(area.element, area.bounds);
+    validateOutOfBounds(effectiveBounds, slideBounds, issues, slideIndex, elementIndex);
+  });
+}
 
 export class QAValidator {
   public async validate(outputPath: string, dsl: PresentationDSL, theme: ThemeDefinition): Promise<QAResult> {
@@ -23,24 +147,17 @@ export class QAValidator {
     }
 
     const layoutEngine = new LayoutEngine(theme);
+    const presetEngine = new PresetEngine();
     const slideBounds = layoutEngine.getSlideBounds();
 
     dsl.slides.forEach((slide, slideIndex) => {
-      if (slide.type !== "content") {
-        return;
+      if (slide.type === "content") {
+        validateContentSlide(slide, slideIndex, layoutEngine, presetEngine, slideBounds, issues);
       }
 
-      const layoutResult = layoutEngine.calculateLayout(slide.content, slide.layout ?? "auto");
-      layoutResult.areas.forEach((area, elementIndex) => {
-        if (!isInsideBounds(area.bounds, slideBounds)) {
-          issues.push({
-            code: "OUT_OF_BOUNDS",
-            message: "Layout area exceeded slide bounds",
-            slideIndex,
-            elementIndex
-          });
-        }
-      });
+      if (slide.type === "blank") {
+        validateBlankSlide(slide, slideIndex, slideBounds, issues);
+      }
     });
 
     return {

--- a/src/renderers/components/image.ts
+++ b/src/renderers/components/image.ts
@@ -1,10 +1,153 @@
 import * as path from "node:path";
+import { imageSize } from "image-size";
 import type { Bounds, ImageElement, ThemeDefinition } from "../../types";
 import type { SlideAdapter } from "../base-renderer";
 import { RenderError } from "../../errors";
 
+type ImageAnchor = NonNullable<ImageElement["position"]>;
+
+interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
 function hasTraversal(value: string): boolean {
   return path.posix.normalize(value.replace(/\\/g, "/")).split("/").includes("..");
+}
+
+function parseDataImageSource(source: string): Buffer | undefined {
+  const separatorIndex = source.indexOf(",");
+  if (separatorIndex < 0) {
+    return undefined;
+  }
+
+  const metadata = source.slice(0, separatorIndex);
+  const data = source.slice(separatorIndex + 1);
+  if (/;base64$/i.test(metadata)) {
+    return Buffer.from(data, "base64");
+  }
+
+  try {
+    return Buffer.from(decodeURIComponent(data), "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveImageDimensions(source: string): ImageDimensions | undefined {
+  try {
+    const result = /^data:image\//i.test(source)
+      ? imageSize(parseDataImageSource(source) ?? Buffer.alloc(0))
+      : imageSize(source);
+    if (result.width === undefined || result.height === undefined || result.width <= 0 || result.height <= 0) {
+      return undefined;
+    }
+
+    return {
+      width: result.width,
+      height: result.height
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveHorizontalAnchorOffset(totalWidth: number, contentWidth: number, anchor: ImageAnchor): number {
+  if (anchor === "left") {
+    return 0;
+  }
+  if (anchor === "right") {
+    return Math.max(0, totalWidth - contentWidth);
+  }
+  return Math.max(0, (totalWidth - contentWidth) / 2);
+}
+
+function resolveContainBounds(bounds: Bounds, dimensions: ImageDimensions, anchor: ImageAnchor): Bounds {
+  const scale = Math.min(bounds.w / dimensions.width, bounds.h / dimensions.height);
+  const w = dimensions.width * scale;
+  const h = dimensions.height * scale;
+
+  return {
+    x: bounds.x + resolveHorizontalAnchorOffset(bounds.w, w, anchor),
+    y: bounds.y + (bounds.h - h) / 2,
+    w,
+    h
+  };
+}
+
+function resolveCoverSizing(bounds: Bounds, dimensions: ImageDimensions, anchor: ImageAnchor): Record<string, unknown> {
+  const imageRatio = dimensions.width / dimensions.height;
+  const boundsRatio = bounds.w / bounds.h;
+
+  if (imageRatio > boundsRatio) {
+    const cropWidth = dimensions.height * boundsRatio;
+    return {
+      type: "crop",
+      x: resolveHorizontalAnchorOffset(dimensions.width, cropWidth, anchor),
+      y: 0,
+      w: cropWidth,
+      h: dimensions.height
+    };
+  }
+
+  const cropHeight = dimensions.width / boundsRatio;
+  return {
+    type: "crop",
+    x: 0,
+    y: (dimensions.height - cropHeight) / 2,
+    w: dimensions.width,
+    h: cropHeight
+  };
+}
+
+function resolveImageLayout(bounds: Bounds, element: ImageElement): Record<string, unknown> {
+  const sizing = element.sizing ?? "contain";
+  const anchor = element.position ?? "center";
+  const dimensions = resolveImageDimensions(element.source);
+  const baseLayout: Record<string, unknown> = {
+    x: bounds.x,
+    y: bounds.y,
+    w: bounds.w,
+    h: bounds.h
+  };
+
+  if (dimensions === undefined) {
+    if (sizing === "contain") {
+      return {
+        ...baseLayout,
+        sizing: {
+          type: "contain",
+          w: bounds.w,
+          h: bounds.h
+        }
+      };
+    }
+
+    return {
+      ...baseLayout,
+      sizing: {
+        type: sizing,
+        w: bounds.w,
+        h: bounds.h
+      }
+    };
+  }
+
+  if (sizing === "contain") {
+    const containBounds = resolveContainBounds(bounds, dimensions, anchor);
+    return {
+      ...baseLayout,
+      x: containBounds.x,
+      y: containBounds.y,
+      w: containBounds.w,
+      h: containBounds.h
+    };
+  }
+
+  return {
+    ...baseLayout,
+    sizing: resolveCoverSizing(bounds, dimensions, anchor)
+  };
 }
 
 export async function renderImage(
@@ -21,12 +164,8 @@ export async function renderImage(
     throw new RenderError("Image source contains path traversal segments");
   }
 
-  const imageOptions: Record<string, unknown> = {
-    x: bounds.x,
-    y: bounds.y,
-    w: bounds.w,
-    h: bounds.h
-  };
+  const effectiveBounds = element.bounds ?? bounds;
+  const imageOptions = resolveImageLayout(effectiveBounds, element);
 
   if (/^data:image\//.test(element.source)) {
     imageOptions.data = element.source;
@@ -38,9 +177,9 @@ export async function renderImage(
 
   if (element.caption !== undefined) {
     slide.addText(element.caption, {
-      x: bounds.x,
-      y: bounds.y + bounds.h - 0.2,
-      w: bounds.w,
+      x: effectiveBounds.x,
+      y: effectiveBounds.y + effectiveBounds.h - 0.2,
+      w: effectiveBounds.w,
       h: 0.2,
       fontFace: theme.typography.fonts.caption,
       fontSize: theme.typography.sizes.caption,

--- a/src/renderers/slide-renderer.ts
+++ b/src/renderers/slide-renderer.ts
@@ -3,6 +3,7 @@ import { RenderError } from "../errors";
 import type {
   Bounds,
   ContentSlide,
+  CustomShapeElement,
   ElementArea,
   FooterChrome,
   PresentationMetadata,
@@ -12,12 +13,13 @@ import type {
   ThemeDefinition,
   TitleSlide
 } from "../types";
-import { LayoutEngine } from "../layout";
+import { DEFAULT_BLANK_ELEMENT_BOUNDS, LayoutEngine, resolveElementBounds } from "../layout";
 import type { ImportedTemplateImageObject, ImportedTemplatePackage, ImportedTemplateShapeObject } from "../template-importer/types";
 import type { ComponentRenderContext, SlideAdapter } from "./base-renderer";
 import { renderContentElement } from "./components";
 import { resolveThemeColor } from "../utils/color";
 import { SLIDE_DIMENSIONS } from "../constants";
+import { PresetEngine } from "../presets";
 
 export interface PresentationAdapter {
   addSlide(): SlideAdapter;
@@ -218,6 +220,13 @@ function remapAreasToPlaceholder(areas: ElementArea[], targetPlaceholderBounds: 
     element: area.element,
     bounds: remapBounds(area.bounds, sourceFrame, targetPlaceholderBounds)
   }));
+}
+
+function remapCustomShape(shape: CustomShapeElement, sourceFrame: Bounds, targetFrame: Bounds): CustomShapeElement {
+  return {
+    ...shape,
+    position: remapBounds(shape.position, sourceFrame, targetFrame)
+  };
 }
 
 function interpolateFooterText(template: string, metadata: PresentationMetadata): string {
@@ -449,15 +458,35 @@ export class SlideRenderer {
     });
 
     const engine = new LayoutEngine(theme);
-    const result = engine.calculateLayout(definition.content, definition.layout ?? "auto");
+    const presetEngine = new PresetEngine();
+    const presetResult =
+      definition.preset !== undefined ? presetEngine.calculateLayout(definition.content, definition.preset) : undefined;
+    const result = presetResult ?? engine.calculateLayout(definition.content, definition.layout ?? "auto");
     const bodyBounds = templateContext?.templatePackage.layout.placeholders.body.bounds;
-    const areas = bodyBounds !== undefined ? remapAreasToPlaceholder(result.areas, bodyBounds) : result.areas;
+    let areas = result.areas;
+    let presetDecorations: CustomShapeElement[] = presetResult?.decorations ?? [];
+
+    if (bodyBounds !== undefined) {
+      if (presetResult !== undefined) {
+        areas = presetResult.areas.map((area) => ({
+          element: area.element,
+          bounds: remapBounds(area.bounds, presetResult.frame, bodyBounds)
+        }));
+        presetDecorations = presetDecorations.map((shape) => remapCustomShape(shape, presetResult.frame, bodyBounds));
+      } else {
+        areas = remapAreasToPlaceholder(result.areas, bodyBounds);
+      }
+    }
 
     const context: ComponentRenderContext = {
       renderElement: async (nestedSlide, nestedElement, bounds, nestedTheme) => {
         await renderContentElement(nestedSlide, nestedElement, bounds, nestedTheme, context);
       }
     };
+
+    for (const decoration of presetDecorations) {
+      await renderContentElement(slide, decoration, decoration.position, theme, context);
+    }
 
     for (const area of areas) {
       await renderContentElement(slide, area.element, area.bounds, theme, context);
@@ -539,18 +568,7 @@ export class SlideRenderer {
     };
 
     for (const element of definition.elements) {
-      const defaultBounds = {
-        x: 0.8,
-        y: 0.8,
-        w: 8.4,
-        h: 4.0
-      };
-      const positionedBounds =
-        element.type === "custom-shape"
-          ? element.position
-          : ("position" in element && typeof element.position === "object" ? element.position : undefined) ??
-            ("bounds" in element && typeof element.bounds === "object" ? element.bounds : undefined);
-      const bounds = positionedBounds ?? defaultBounds;
+      const bounds = resolveElementBounds(element, DEFAULT_BLANK_ELEMENT_BOUNDS);
       await renderContentElement(slide, element, bounds, theme, context);
     }
   }

--- a/src/types/dsl.ts
+++ b/src/types/dsl.ts
@@ -54,6 +54,7 @@ export interface ElementPosition {
 }
 
 export type Slide = TitleSlide | ContentSlide | SectionSlide | BlankSlide;
+export type PresetId = "overview-2x2" | "compare-3col" | "kpi-with-callout";
 
 export type SlideBackground =
   | "dark"
@@ -77,6 +78,7 @@ export interface TitleSlide {
 export interface ContentSlide {
   type: "content";
   layout?: LayoutType;
+  preset?: PresetId;
   title: string;
   content: ContentElement[];
 }
@@ -100,9 +102,14 @@ export interface BlankSlide {
 export type TextStyle = "title" | "heading" | "body" | "caption";
 export type Alignment = "left" | "center" | "right";
 
+export interface ElementQAOptions {
+  exclude?: boolean;
+}
+
 export interface TextElement {
   type: "text";
   content: string;
+  slot?: string;
   style?: TextStyle;
   align?: Alignment;
   position?: ElementPosition;
@@ -111,6 +118,7 @@ export interface TextElement {
   fontSize?: number;
   bold?: boolean;
   valign?: "top" | "mid" | "bottom";
+  qa?: ElementQAOptions;
 }
 
 export interface BulletItem {
@@ -120,33 +128,41 @@ export interface BulletItem {
 
 export interface BulletListElement {
   type: "bullet-list";
+  slot?: string;
   style?: "default" | "pros" | "cons" | "checkmark";
   items: Array<string | BulletItem>;
   position?: ElementPosition;
+  qa?: ElementQAOptions;
 }
 
 export interface NumberedListElement {
   type: "numbered-list";
+  slot?: string;
   items: string[];
   position?: ElementPosition;
+  qa?: ElementQAOptions;
 }
 
 export interface StatCalloutElement {
   type: "stat-callout";
+  slot?: string;
   value: string;
   label: string;
   trend?: string;
   color?: string;
   position?: ElementPosition;
+  qa?: ElementQAOptions;
 }
 
 export interface ImageElement {
   type: "image";
+  slot?: string;
   source: string;
   caption?: string;
   sizing?: "contain" | "cover" | "crop";
   position?: "center" | "left" | "right";
   bounds?: ElementPosition;
+  qa?: ElementQAOptions;
 }
 
 export interface TableHighlightRule {
@@ -157,11 +173,13 @@ export interface TableHighlightRule {
 
 export interface TableElement {
   type: "table";
+  slot?: string;
   style?: "default" | "striped" | "bordered" | "minimal";
   headers: string[];
   rows: Array<Array<string | number>>;
   highlight?: TableHighlightRule[];
   position?: ElementPosition;
+  qa?: ElementQAOptions;
 }
 
 export interface ChartSeries {
@@ -172,6 +190,7 @@ export interface ChartSeries {
 
 export interface ChartElement {
   type: "chart";
+  slot?: string;
   chartType: "bar" | "line" | "pie" | "doughnut" | "scatter";
   title?: string;
   position?: ElementPosition;
@@ -185,6 +204,7 @@ export interface ChartElement {
     valuePrefix?: string;
     valueSuffix?: string;
   };
+  qa?: ElementQAOptions;
 }
 
 export interface NetworkNode {
@@ -203,10 +223,12 @@ export interface NetworkEdge {
 
 export interface NetworkDiagramElement {
   type: "network-diagram";
+  slot?: string;
   layout: "hierarchical" | "force-directed" | "circular";
   nodes: NetworkNode[];
   edges: NetworkEdge[];
   position?: ElementPosition;
+  qa?: ElementQAOptions;
 }
 
 export interface FlowchartStep {
@@ -223,10 +245,12 @@ export interface FlowchartFlow {
 
 export interface FlowchartElement {
   type: "flowchart";
+  slot?: string;
   direction: "horizontal" | "vertical";
   steps: FlowchartStep[];
   flows: FlowchartFlow[];
   position?: ElementPosition;
+  qa?: ElementQAOptions;
 }
 
 export interface IconGridItem {
@@ -237,17 +261,21 @@ export interface IconGridItem {
 
 export interface IconGridElement {
   type: "icon-grid";
+  slot?: string;
   columns: number;
   items: IconGridItem[];
   position?: ElementPosition;
+  qa?: ElementQAOptions;
 }
 
 export interface TwoColumnElement {
   type: "two-column";
+  slot?: string;
   left: ContentElement[];
   right: ContentElement[];
   ratio?: "1:1" | "2:1" | "1:2";
   position?: ElementPosition;
+  qa?: ElementQAOptions;
 }
 
 export interface CustomShapeElement {
@@ -264,6 +292,7 @@ export interface CustomShapeElement {
     color: string;
     width: number;
   };
+  qa?: ElementQAOptions;
 }
 
 export type ContentElement =

--- a/tests/unit/normalizer.spec.ts
+++ b/tests/unit/normalizer.spec.ts
@@ -93,6 +93,13 @@ describe("DSLNormalizer", () => {
     }
     expect(twoColumn.ratio).toBe("1:1");
 
+    const image = contentSlide.content.find((element) => element.type === "image");
+    if (image?.type !== "image") {
+      throw new Error("expected image");
+    }
+    expect(image.sizing).toBe("contain");
+    expect(image.position).toBe("center");
+
     const sectionSlide = normalized.slides[2];
     if (sectionSlide?.type !== "section") {
       throw new Error("expected section slide");

--- a/tests/unit/parser-advanced.spec.ts
+++ b/tests/unit/parser-advanced.spec.ts
@@ -76,4 +76,64 @@ describe("DSLValidator semantic checks", () => {
     const result = validator.validate(dsl);
     expect(result.isValid).toBe(true);
   });
+
+  it("detects preset slot violations", () => {
+    const validator = new DSLValidator({ allowRemoteImages: true });
+    const dsl = {
+      version: "1.0",
+      theme: "corporate-blue",
+      metadata: { title: "preset-invalid" },
+      slides: [
+        {
+          type: "content",
+          preset: "overview-2x2",
+          title: "Preset",
+          content: [
+            { type: "text", content: "a", slot: "card1" },
+            {
+              type: "chart",
+              chartType: "bar",
+              slot: "card1",
+              data: {
+                labels: ["Q1"],
+                series: [{ name: "S", values: [1] }]
+              }
+            },
+            { type: "text", content: "x", slot: "missing-slot" }
+          ]
+        }
+      ]
+    };
+
+    const result = validator.validate(dsl);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some((error) => error.includes("duplicates slot"))).toBe(true);
+    expect(result.errors.some((error) => error.includes("not allowed in slot"))).toBe(true);
+    expect(result.errors.some((error) => error.includes("undefined slot"))).toBe(true);
+  });
+
+  it("accepts valid preset slot mapping", () => {
+    const validator = new DSLValidator({ allowRemoteImages: true });
+    const dsl = {
+      version: "1.0",
+      theme: "corporate-blue",
+      metadata: { title: "preset-valid" },
+      slides: [
+        {
+          type: "content",
+          preset: "compare-3col",
+          title: "Preset",
+          content: [
+            { type: "text", content: "L", slot: "left" },
+            { type: "bullet-list", items: ["C"], slot: "center" },
+            { type: "numbered-list", items: ["R1"], slot: "right" },
+            { type: "text", content: "Summary" }
+          ]
+        }
+      ]
+    };
+
+    const result = validator.validate(dsl);
+    expect(result.isValid).toBe(true);
+  });
 });

--- a/tests/unit/parser.spec.ts
+++ b/tests/unit/parser.spec.ts
@@ -134,4 +134,24 @@ describe("DSLParser", () => {
     expect(result.isValid).toBe(false);
     expect(result.errors.some((error) => error.includes("String length"))).toBe(true);
   });
+
+  it("rejects unknown preset id", () => {
+    const parser = new DSLParser();
+    const result = parser.validate({
+      version: "1.0",
+      theme: "corporate-blue",
+      metadata: { title: "preset" },
+      slides: [
+        {
+          type: "content",
+          title: "x",
+          preset: "unknown-preset",
+          content: [{ type: "text", content: "y" }]
+        }
+      ]
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some((error) => error.includes("preset"))).toBe(true);
+  });
 });

--- a/tests/unit/presets.spec.ts
+++ b/tests/unit/presets.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { PresetEngine, getPresetDefinition } from "../../src/presets";
+import type { ContentElement } from "../../src/types";
+
+describe("PresetEngine", () => {
+  it("maps elements to explicit and default slots", () => {
+    const engine = new PresetEngine();
+    const elements: ContentElement[] = [
+      { type: "text", content: "left", slot: "left" },
+      { type: "text", content: "summary-a" },
+      { type: "text", content: "summary-b" }
+    ];
+
+    const result = engine.calculateLayout(elements, "compare-3col");
+    expect(result.areas).toHaveLength(3);
+    expect(result.areas[0]?.bounds.x).toBeCloseTo(0.8, 2);
+    expect(result.areas[1]?.bounds.y).toBeGreaterThanOrEqual(4.25);
+    expect(result.areas[2]?.bounds.y).toBeGreaterThan(result.areas[1]?.bounds.y ?? 0);
+  });
+
+  it("includes preset decorations", () => {
+    const definition = getPresetDefinition("overview-2x2");
+    const engine = new PresetEngine();
+    const result = engine.calculateLayout([{ type: "text", content: "a", slot: "card1" }], "overview-2x2");
+
+    expect(result.decorations.length).toBe(definition?.decorations?.length ?? 0);
+    expect(result.frame.w).toBeGreaterThan(0);
+    expect(result.frame.h).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/qa.spec.ts
+++ b/tests/unit/qa.spec.ts
@@ -37,4 +37,110 @@ describe("QAEngine", () => {
     const result = await qa.validate(outputPath, dsl, testTheme);
     expect(result.hasIssues).toBe(false);
   });
+
+  it("detects out-of-bounds elements on blank slide", async () => {
+    const qa = new QAEngine();
+    const outputPath = path.resolve(process.cwd(), ".tmp", "qa", "blank-oob.pptx");
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, Buffer.from("ok"));
+
+    const result = await qa.validate(
+      outputPath,
+      {
+        version: "1.0",
+        theme: "corporate-blue",
+        metadata: { title: "blank-oob" },
+        slides: [
+          {
+            type: "blank",
+            elements: [
+              {
+                type: "text",
+                content: "overflow",
+                position: { x: 9.6, y: 1.2, w: 1.0, h: 0.8 }
+              }
+            ]
+          }
+        ]
+      },
+      testTheme
+    );
+
+    expect(result.hasIssues).toBe(true);
+    expect(result.issues.some((issue) => issue.code === "OUT_OF_BOUNDS")).toBe(true);
+  });
+
+  it("ignores decorative shapes when checking overlap on blank slide", async () => {
+    const qa = new QAEngine();
+    const outputPath = path.resolve(process.cwd(), ".tmp", "qa", "blank-decorative.pptx");
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, Buffer.from("ok"));
+
+    const result = await qa.validate(
+      outputPath,
+      {
+        version: "1.0",
+        theme: "corporate-blue",
+        metadata: { title: "blank-decorative" },
+        slides: [
+          {
+            type: "blank",
+            elements: [
+              {
+                type: "custom-shape",
+                shape: "rectangle",
+                position: { x: 0.8, y: 1.0, w: 8.4, h: 2.0 },
+                fill: "DEE2E6"
+              },
+              {
+                type: "text",
+                content: "foreground",
+                position: { x: 1.0, y: 1.4, w: 3.0, h: 1.2 }
+              }
+            ]
+          }
+        ]
+      },
+      testTheme
+    );
+
+    expect(result.issues.some((issue) => issue.code === "EXCESSIVE_OVERLAP")).toBe(false);
+  });
+
+  it("reports excessive overlap for non-decorative elements", async () => {
+    const qa = new QAEngine();
+    const outputPath = path.resolve(process.cwd(), ".tmp", "qa", "blank-overlap.pptx");
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, Buffer.from("ok"));
+
+    const result = await qa.validate(
+      outputPath,
+      {
+        version: "1.0",
+        theme: "corporate-blue",
+        metadata: { title: "blank-overlap" },
+        slides: [
+          {
+            type: "blank",
+            elements: [
+              {
+                type: "text",
+                content: "A",
+                position: { x: 1.0, y: 1.2, w: 4.0, h: 2.0 }
+              },
+              {
+                type: "text",
+                content: "B",
+                position: { x: 2.0, y: 1.4, w: 4.0, h: 2.0 }
+              }
+            ]
+          }
+        ]
+      },
+      testTheme
+    );
+
+    expect(result.hasIssues).toBe(true);
+    expect(result.issues.some((issue) => issue.code === "EXCESSIVE_OVERLAP")).toBe(true);
+  });
 });

--- a/tests/unit/renderers.spec.ts
+++ b/tests/unit/renderers.spec.ts
@@ -21,12 +21,32 @@ import { testTheme } from "../helpers/theme";
 import { MockPresentation, MockSlide } from "../helpers/mock-slide";
 
 const bounds: Bounds = { x: 0.5, y: 1, w: 4, h: 2 };
+const tallSvgData = `data:image/svg+xml;base64,${Buffer.from(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="200"></svg>'
+).toString("base64")}`;
+const wideSvgData = `data:image/svg+xml;base64,${Buffer.from(
+  '<svg xmlns="http://www.w3.org/2000/svg" width="300" height="100"></svg>'
+).toString("base64")}`;
 
 const context = {
   renderElement: async (slide: SlideAdapter, element: unknown, nextBounds: Bounds) => {
     await renderContentElement(slide, element, nextBounds, testTheme, context);
   }
 };
+
+function readImageOptions(slide: MockSlide, index: number): Record<string, unknown> {
+  const call = slide.calls.filter((entry) => entry.kind === "image")[index];
+  if (call?.kind !== "image") {
+    throw new Error(`expected image call at index ${index}`);
+  }
+
+  const payload = call.payload as { options?: Record<string, unknown> };
+  if (payload.options === undefined) {
+    throw new Error(`expected image options at index ${index}`);
+  }
+
+  return payload.options;
+}
 
 describe("component renderers", () => {
   it("renders text and list components", () => {
@@ -112,6 +132,140 @@ describe("component renderers", () => {
         testTheme
       )
     ).rejects.toThrowError(/disabled/i);
+  });
+
+  it("respects contain sizing with left/center/right anchors", async () => {
+    const slide = new MockSlide();
+
+    await renderImage(
+      slide,
+      {
+        type: "image",
+        source: tallSvgData,
+        sizing: "contain",
+        position: "left"
+      },
+      bounds,
+      testTheme
+    );
+
+    await renderImage(
+      slide,
+      {
+        type: "image",
+        source: tallSvgData,
+        sizing: "contain",
+        position: "center"
+      },
+      bounds,
+      testTheme
+    );
+
+    await renderImage(
+      slide,
+      {
+        type: "image",
+        source: tallSvgData,
+        sizing: "contain",
+        position: "right"
+      },
+      bounds,
+      testTheme
+    );
+
+    const left = readImageOptions(slide, 0);
+    const center = readImageOptions(slide, 1);
+    const right = readImageOptions(slide, 2);
+
+    expect(left.x).toBeCloseTo(0.5, 5);
+    expect(center.x).toBeCloseTo(2.0, 5);
+    expect(right.x).toBeCloseTo(3.5, 5);
+    expect(left.y).toBeCloseTo(1.0, 5);
+    expect(left.w).toBeCloseTo(1.0, 5);
+    expect(left.h).toBeCloseTo(2.0, 5);
+    expect(left.sizing).toBeUndefined();
+  });
+
+  it("uses anchor-aware crop sizing for cover and crop modes", async () => {
+    const slide = new MockSlide();
+
+    await renderImage(
+      slide,
+      {
+        type: "image",
+        source: wideSvgData,
+        sizing: "cover",
+        position: "left"
+      },
+      bounds,
+      testTheme
+    );
+
+    await renderImage(
+      slide,
+      {
+        type: "image",
+        source: wideSvgData,
+        sizing: "cover",
+        position: "right"
+      },
+      bounds,
+      testTheme
+    );
+
+    await renderImage(
+      slide,
+      {
+        type: "image",
+        source: wideSvgData,
+        sizing: "crop",
+        position: "center"
+      },
+      bounds,
+      testTheme
+    );
+
+    const leftCover = readImageOptions(slide, 0);
+    const rightCover = readImageOptions(slide, 1);
+    const centerCrop = readImageOptions(slide, 2);
+    const leftSizing = leftCover.sizing as { type: string; x: number; y: number; w: number; h: number };
+    const rightSizing = rightCover.sizing as { type: string; x: number; y: number; w: number; h: number };
+    const centerSizing = centerCrop.sizing as { type: string; x: number; y: number; w: number; h: number };
+
+    expect(leftCover.x).toBe(bounds.x);
+    expect(leftCover.y).toBe(bounds.y);
+    expect(leftCover.w).toBe(bounds.w);
+    expect(leftCover.h).toBe(bounds.h);
+    expect(leftSizing.type).toBe("crop");
+    expect(rightSizing.type).toBe("crop");
+    expect(centerSizing.type).toBe("crop");
+    expect(leftSizing.x).toBeCloseTo(0, 5);
+    expect(centerSizing.x).toBeCloseTo(50, 5);
+    expect(rightSizing.x).toBeCloseTo(100, 5);
+    expect(leftSizing.w).toBeCloseTo(200, 5);
+    expect(leftSizing.h).toBeCloseTo(100, 5);
+    expect(leftSizing.y).toBeCloseTo(0, 5);
+  });
+
+  it("prioritizes image bounds over layout bounds", async () => {
+    const slide = new MockSlide();
+    await renderImage(
+      slide,
+      {
+        type: "image",
+        source: wideSvgData,
+        sizing: "cover",
+        bounds: { x: 2.2, y: 1.8, w: 3.3, h: 1.1 }
+      },
+      bounds,
+      testTheme
+    );
+
+    const options = readImageOptions(slide, 0);
+    expect(options.x).toBeCloseTo(2.2, 5);
+    expect(options.y).toBeCloseTo(1.8, 5);
+    expect(options.w).toBeCloseTo(3.3, 5);
+    expect(options.h).toBeCloseTo(1.1, 5);
   });
 
   it("renders shape/stat/icon/network/flowchart", () => {
@@ -517,6 +671,150 @@ describe("SlideRenderer", () => {
     expect((bodyOptions?.y as number) >= 1.4).toBe(true);
     expect((bodyOptions?.w as number) <= 8.01).toBe(true);
     expect((bodyOptions?.h as number) <= 3.51).toBe(true);
+  });
+
+  it("renders preset content slots and decorations", async () => {
+    const renderer = new SlideRenderer();
+    const presentation = new MockPresentation();
+
+    const dsl: PresentationDSL = {
+      version: "1.0",
+      theme: "corporate-blue",
+      metadata: { title: "preset-render" },
+      slides: [
+        {
+          type: "content",
+          preset: "compare-3col",
+          title: "Preset slide",
+          content: [
+            { type: "text", content: "Left", slot: "left" },
+            { type: "text", content: "Center", slot: "center" },
+            { type: "text", content: "Right", slot: "right" },
+            { type: "text", content: "Summary" }
+          ]
+        }
+      ]
+    };
+
+    await renderer.renderSlides(presentation, dsl, testTheme);
+    const slide = presentation.slides[0];
+    if (slide === undefined) {
+      throw new Error("expected slide");
+    }
+
+    const shapeCalls = slide.calls.filter((call) => call.kind === "shape");
+    expect(shapeCalls.length).toBeGreaterThanOrEqual(3);
+
+    const textEntries = slide.calls
+      .filter((call) => call.kind === "text")
+      .map((call) => call.payload as { text: string; options?: Record<string, unknown> });
+    const left = textEntries.find((entry) => entry.text === "Left");
+    const center = textEntries.find((entry) => entry.text === "Center");
+    const right = textEntries.find((entry) => entry.text === "Right");
+    const summary = textEntries.find((entry) => entry.text === "Summary");
+
+    expect((left?.options?.x as number) < (center?.options?.x as number)).toBe(true);
+    expect((center?.options?.x as number) < (right?.options?.x as number)).toBe(true);
+    expect((summary?.options?.y as number) >= 4.25).toBe(true);
+  });
+
+  it("remaps preset bounds into template body placeholder", async () => {
+    const renderer = new SlideRenderer();
+    const presentation = new MockPresentation();
+    const templateContext: SlideTemplateContext = {
+      assetBaseDir: process.cwd(),
+      templatePackage: {
+        template: {
+          id: "preset-template",
+          source: {
+            file: "sample.potx",
+            sha256: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+            importedAt: "2026-03-01T00:00:00.000Z"
+          }
+        },
+        theme: {
+          palette: {
+            primary: "0B5FFF",
+            secondary: "00A99D",
+            accent: "FF6A00",
+            "text-dark": "1A1A1A",
+            "text-light": "FFFFFF",
+            "background-light": "FAFAFA",
+            "background-dark": "121212"
+          },
+          fonts: {
+            title: "Noto Sans",
+            heading: "Noto Sans",
+            body: "Noto Sans JP",
+            caption: "Noto Sans JP"
+          },
+          slideSize: "16:9"
+        },
+        layout: {
+          kind: "title-body",
+          placeholders: {
+            title: {
+              bounds: { x: 1.1, y: 0.25, w: 7.8, h: 0.7 },
+              style: { fontFace: "Noto Sans", fontSizePt: 28, color: "primary" }
+            },
+            body: {
+              bounds: { x: 1.0, y: 1.4, w: 8.0, h: 3.5 },
+              style: { fontFace: "Noto Sans JP", fontSizePt: 18, color: "text-dark" }
+            }
+          }
+        },
+        background: {
+          mode: "editable",
+          color: "background-light",
+          objects: []
+        },
+        manifest: {
+          warnings: [],
+          unsupported: []
+        }
+      }
+    };
+
+    const dsl: PresentationDSL = {
+      version: "1.0",
+      theme: "corporate-blue",
+      metadata: { title: "preset-template" },
+      slides: [
+        {
+          type: "content",
+          preset: "compare-3col",
+          title: "Preset + Template",
+          content: [
+            { type: "text", content: "Left", slot: "left" },
+            { type: "text", content: "Center", slot: "center" },
+            { type: "text", content: "Right", slot: "right" }
+          ]
+        }
+      ]
+    };
+
+    await renderer.renderSlides(presentation, dsl, testTheme, templateContext);
+    const slide = presentation.slides[0];
+    if (slide === undefined) {
+      throw new Error("expected slide");
+    }
+
+    const textCalls = slide.calls
+      .filter((call) => call.kind === "text")
+      .map((call) => call.payload as { text: string; options?: Record<string, unknown> })
+      .filter((entry) => ["Left", "Center", "Right"].includes(entry.text));
+
+    expect(textCalls.length).toBe(3);
+    textCalls.forEach((entry) => {
+      const x = entry.options?.x as number;
+      const y = entry.options?.y as number;
+      const w = entry.options?.w as number;
+      const h = entry.options?.h as number;
+      expect(x).toBeGreaterThanOrEqual(1.0);
+      expect(y).toBeGreaterThanOrEqual(1.4);
+      expect(x + w).toBeLessThanOrEqual(9.01);
+      expect(y + h).toBeLessThanOrEqual(4.91);
+    });
   });
 
   it("applies template objects to title/section and renders footer chrome", async () => {


### PR DESCRIPTION
## Summary
- Implemented full `ImageElement` behavior alignment (`sizing/position/bounds`) with runtime rendering logic and tests.
- Added a new preset layer for `content` slides (`overview-2x2`, `compare-3col`, `kpi-with-callout`) with `slot` mapping, validation, and renderer support.
- Extended QA to validate `blank` slides, detect excessive overlap among non-decorative elements, and share element-bounds resolution logic with renderer.
- Reorganized docs with explicit Must/Should/May guidance, layout selection table, preset usage, and review checklist.

## Implementation Details
- `src/renderers/components/image.ts`
  - Added image-dimension-aware placement.
  - `contain` now preserves aspect ratio and respects `position` (`left/center/right`).
  - `cover/crop` now apply anchor-aware cropping.
  - `element.bounds` now overrides fallback layout bounds.
- `src/presets/*`
  - Introduced preset catalog + engine.
  - Added decoration rendering and frame-based remap to template body placeholder.
- `src/types/dsl.ts`, `src/parser/schema.ts`, `src/parser/validator.ts`
  - Added `content.preset` and per-element `slot`.
  - Added optional per-element `qa.exclude`.
  - Added semantic validation for slot existence, duplicate slot assignment, and slot/type compatibility.
- `src/layout/element-bounds.ts`, `src/renderers/slide-renderer.ts`, `src/qa/validator.ts`
  - Extracted shared bounds resolution utility.
  - QA now checks both `content` and `blank` slides for out-of-bounds.
  - Added overlap checks on blank slides while excluding decorative elements by default.
- Updated docs:
  - `docs/template-design-spec.md`
  - `docs/usage-guide.md`
  - `docs/api-reference.md`
  - `example/README.md`

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:security`
- `npm run example:test`
- `npm run build`

Closes #19
Closes #20
Closes #21
Closes #22
